### PR TITLE
#55:

### DIFF
--- a/source/gppMain.pas
+++ b/source/gppMain.pas
@@ -354,7 +354,6 @@ type
     procedure FillUnitView(resortOn: integer = -1);
     procedure FillThreadView(resortOn: integer = -1);
     function  GetThreadName(index: integer): string;
-    procedure EnumUserSettings(settings: TStrings);
     procedure FillDelphiVer;
     function  GetSearchPath(const aProject: string): string;
     function  GetOutputDir(const aProject: string): string;
@@ -864,81 +863,7 @@ begin
   end;
 end;
 
-procedure TfrmMain.EnumUserSettings(settings: TStrings);
-var
-  vTempSL: TStrings;
-  i: Integer;
-begin
-  { returns the user settings that exist in the registry }
-  with TRegistry.Create do  begin
-  try
 
-      // Enumerate Delphi 2009-XE3
-      RootKey := HKEY_CURRENT_USER;
-      if OpenKeyReadOnly('\SOFTWARE\Embarcadero\BDS') then
-      begin
-        try
-          vTempSL := TStringList.Create;
-          try
-            GetKeyNames(vTempSL);
-            for i := 0 to vTempSL.Count-1 do
-            begin
-              settings.Add(BdsVerToDephiVer(vTempSL[i]));
-            end;
-          finally
-            vTempSL.Free;
-          end;
-        finally
-          CloseKey;
-        end;
-      end;
-
-      // Enumerate Delphi 2005-2007
-      RootKey := HKEY_CURRENT_USER;
-      if OpenKeyReadOnly('\SOFTWARE\Borland\BDS') then
-      begin
-        try
-          vTempSL := TStringList.Create;
-          try
-            GetKeyNames(vTempSL);
-            for i := 0 to vTempSL.Count-1 do
-              if vTempSL[i] = '5.0' then
-                settings.Add('2007')
-              else if vTempSL[i] = '4.0' then
-                settings.Add('2006')
-              else if vTempSL[i] = '3.0' then
-                settings.Add('2005')
-              else
-                settings.Add('Borland BDS ' + vTempSL[i]);
-          finally
-            vTempSL.Free;
-          end;
-        finally
-          CloseKey;
-        end;
-      end;
-
-      RootKey := HKEY_LOCAL_MACHINE;
-      // Enumerate Delphi versions 2-5
-      if OpenKeyReadOnly('\SOFTWARE\Borland\Delphi') then
-      begin
-        try
-          vTempSL := TStringList.Create;
-          try
-            GetKeyNames(vTempSL);
-            settings.AddStrings(vTempSL);
-          finally
-            vTempSL.Free;
-          end;
-        finally
-          CloseKey;
-        end;
-      end;
-    finally
-      Free;
-    end;
-  end;
-end;
 
 { TfrmMain.EnablePC2 }
 
@@ -1238,7 +1163,7 @@ var
 begin
   s := TStringList.Create;
   try
-    EnumUserSettings(s);
+    FillInDelphiVersions(s);
     for i := 0 to s.Count-1 do begin
       mn := TMenuItem.Create(self);
       mn.Caption := 'Delphi &'+s[i];
@@ -2401,7 +2326,7 @@ var
 begin
   s := TStringList.Create;
   try
-    EnumUserSettings(s);
+    FillInDelphiVersions(s);
     verch := Chr(delphiVer+Ord('0'));
     setting := s.Count-1;
     for i := 0 to s.Count-2 do


### PR DESCRIPTION
o renamed EnumSettings to bdsVersions as FillInDelphiVersions()
+ FillInDelphiVersions(): using inner function to remove double code
+ FillInDelphiVersions(): clearing list instead of recreating to avoid finally stuff (not needed)
+ FillInDelphiVersions(): checking "APP" key in registry to ensure bds.exe really exists.