### PR TITLE
Updated ProjectHome.md

### DIFF
--- a/ProjectHome.md
+++ b/ProjectHome.md
@@ -8,10 +8,8 @@ Small changes to make it work with Delphi XE2, XE3: Johan Bontes (johan@digitsol
 
 Note: source code must be compiled with CodeGear Delphi 2007, as most parts of it are not compatible with newer (Unicode) versions of Delphi.
 
-You can support the project by [Donating](http://emorio.com).
-
 You may also like:
 
-[OmniThreadLibrary](https://code.google.com/p/omnithreadlibrary) - incredible multithreading library for Delphi
+[OmniThreadLibrary](https://github.com/gabr42/OmniThreadLibrary) - incredible multithreading library for Delphi
 
 [SapMM](https://code.google.com/p/sapmm) - outstanding and mega-fast scalable memory manager for multithreaded Delphi applications.


### PR DESCRIPTION
- removed donation link to domain that is currently being sold
o changed link to the OmniThreadLibrary which was moved from `code.google.com` to `GitHub`