### PR TITLE
Fix partial import

### DIFF
--- a/source/model/profilingResultParser/gppResults.procs.pas
+++ b/source/model/profilingResultParser/gppResults.procs.pas
@@ -108,16 +108,18 @@ procedure TActiveProcList.LocateLast(procID: integer; var this,parent: TProcProx
 var
   i: integer;
 begin
-  for i := fAplList.Count-1 downto 0 do
-  begin
-    if fAplList[i].ppProcID = procID then
+  if (fAplList <> nil) and (fAplList.Count >= 0) then begin
+    for i := fAplList.Count-1 downto 0 do
     begin
-      this := fAplList[i];
-      if i > 0 then
-        parent := fAplList[i-1]
-      else
-        parent := nil;
-      Exit;
+      if fAplList[i].ppProcID = procID then
+      begin
+        this := fAplList[i];
+        if i > 0 then
+          parent := fAplList[i-1]
+        else
+          parent := nil;
+        Exit;
+      end;
     end;
   end;
   this   := nil;

--- a/source/model/profilingResultParser/gppresults.pas
+++ b/source/model/profilingResultParser/gppresults.pas
@@ -495,12 +495,15 @@ var
   proxy : TProcProxy;
   parent: TProcProxy;
 begin
-  resThreads[ThLocate(pkt.rpThread)].teActiveProcs.LocateLast(pkt.rpProcID,proxy,parent);
-  if proxy = nil then
-    raise Exception.Create('gppResults.TResults.ExitProcPkt: Entry not found!');
-  ExitProc(proxy,parent,pkt);
-  proxy.Destroy;
-  inherited;
+  const tid = ThLocate(pkt.rpThread);
+  if (tid >= 0) and (resThreads[tid].teActiveProcs <> nil) then begin
+    resThreads[tid].teActiveProcs.LocateLast(pkt.rpProcID,proxy,parent);
+    if proxy = nil then
+      raise Exception.Create('gppResults.TResults.ExitProcPkt: Entry not found!');
+    ExitProc(proxy,parent,pkt);
+    proxy.Destroy;
+    inherited;
+  end;
 end; { TResults.ExitProcPkt }
 
 procedure TResults.AddEnterProc(pkt: TResPacket);


### PR DESCRIPTION
When importing an instrumentation file that misses some ProfileStart data (e.g. Profiling was started from within a method and/or other Threads already running), the import failed because of missing references. These failures are now ignored.