### PR TITLE
Use NativeUInt for pointer arithmetic

### DIFF
--- a/include/GpProf.pas
+++ b/include/GpProf.pas
@@ -125,7 +125,7 @@ end; { FlushFile }
 
 function OffsetPtr(ptr: pointer; offset: DWORD): pointer;
 begin
-  Result := pointer(DWORD(ptr)+offset);
+  Result := pointer(NativeUInt(ptr)+offset);
 end; { OffsetPtr }
 
 procedure Transmit(const buf; count: DWORD);


### PR DESCRIPTION
When using the include folder in a project compiled for 64 bit, the OffsetPtr method does not work (it will give an access violation afterwards, as the pointer is truncated to 32 bit).

Using `NativeUInt` instead of `DWORD` for the pointer arithmetics solves this.