### PR TITLE
GpProf.pas and GpProfCommon.pas with Delphi 2007 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Features are:
 - New shiny UI with high DPI support.
 - Applying project defines in the parser to support multi-target code.
 - A whole lot of bug fixes
-- Using NameThreadForDebugging() for tracing the thread names in the result files.
+- Using `NameThreadForDebugging()` for tracing the thread names in the result files.
 - The PRF output filename can be now be configured using several placeholders, e.g. the ModuleName or the ProcessName and ID.
 - 32 and 64 Bit support.
 - Low performance impact on the subject that is instrumented.
@@ -27,11 +27,25 @@ Easy as 1-2-3:
 3) Copy the content of the include dir into your application sources folder or add the include dir to the search path. Build your application in Delphi, run it, do some tasks and close.
 
 After that return to GpProfile window and enjoy the results! :)
-## Measure Points ##
-Since Version 1.6.0, you can add measurePoints:
-Use gpprof.CreateMeasurePointScope() to obtain a measure point. Upon disposal, the measure point will write out the timings.
 
-A sample can be found in the GProfTester project (in TTestThread.Execute())  
+## Measure Points ##
+Since Version 1.6.0, you can add Measure Points:
+
+Use `GpProf.CreateMeasurePointScope` or low-level API to obtain a measure point. Upon disposal, the measure point will write out the timings.
+
+```pascal
+// Using measure point scope
+var mp1 := CreateMeasurePointScope('MP-1');
+... // do some work
+mp1 := nil;
+```
+
+```pascal
+// Using low-level API (zero memory allocation)
+ProfilerEnterMP('MP-1');
+... // do some work
+ProfilerExitMP('MP-1');
+```
 
 # Credits #
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,14 @@ Easy as 1-2-3:
 After that return to GpProfile window and enjoy the results! :)
 
 ## Measure Points ##
-Since Version 1.6.0, you can add Measure Points:
+Since version 1.6.0, you can add **measure points**:
 
-Use `GpProf.CreateMeasurePointScope` or low-level API to obtain a measure point. Upon disposal, the measure point will write out the timings.
+Use `CreateMeasurePointScope` or the low-level API (`ProfilerEnterMP` and `ProfilerExitMP` functions) from [GpProf.pas](./include/GpProf.pas) to create a measure point. When the scope is released, the measure point will write out the timings.
 
 ```pascal
+uses
+  GpProf;
+...
 // Using measure point scope
 var mp1 := CreateMeasurePointScope('MP-1');
 ... // do some work
@@ -41,10 +44,13 @@ mp1 := nil;
 ```
 
 ```pascal
+uses
+  GpProf;
+...
 // Using low-level API (zero memory allocation)
 ProfilerEnterMP('MP-1');
 ... // do some work
-ProfilerExitMP('MP-1');
+ProfilerExitMP('MP-1'); // make sure to pass exactly the same name as in ProfilerEnterMP
 ```
 
 # Credits #

--- a/include/GpProf.pas
+++ b/include/GpProf.pas
@@ -466,37 +466,40 @@ end; { TThreadList.Search }
 
 procedure ReadIncSettings;
 var
-  buf: array [0..256] of char;
-  ini: string;
+  LBuf: array [0..256] of char;
+  LIniFileName: string;
+  LIni: TMemIniFile;
 begin
-  GetModuleFileName(HInstance,buf,256);
-  prfModuleName := string(buf);
+  GetModuleFileName(HInstance,LBuf,256);
+  prfModuleName := string(LBuf);
   prfDisabled := true;
   profProfilingAutostart := false;
-  ini := Copy(prfModuleName,1,Length(prfModuleName)-Length(ExtractFileExt(prfModuleName)))+'.GPI';
-  if not FileExists(ini) then
+  LIniFileName := Copy(prfModuleName,1,Length(prfModuleName)-Length(ExtractFileExt(prfModuleName)))+'.GPI';
+  if not FileExists(LIniFileName) then
     MessageBox(0, PChar(Format('Cannot find initialization file %s! '+
-      'Profiling will be disabled.', [ini])), 'GpProfile', MB_OK + MB_ICONERROR)
+      'Profiling will be disabled.', [LIniFileName])), 'GpProfile', MB_OK + MB_ICONERROR)
   else begin
-    with TIniFile.Create(ini) do begin
-      profTableName := ReadString('IDTables','TableName','');
+    LIni := TMemIniFile.Create(LIniFileName);
+    try
+      profTableName := LIni.ReadString('IDTables','TableName','');
       if profTableName <> '' then begin
         if not FileExists(profTableName) then
           MessageBox(0, PChar(Format('Cannot find data file %s! '+
             'Profiling will be disabled.', [profTableName])), 'GpProfile',
             MB_OK + MB_ICONERROR)
         else begin
-          profProcSize           := ReadInteger('Procedures','ProcSize',4);
-          profCompressTicks      := ReadBool('Performance','CompressTicks',false);
-          profCompressThreads    := ReadBool('Performance','CompressThreads',false);
-          profProfilingAutostart := ReadBool('Performance','ProfilingAutostart',true);
-          profProfilingMemoryEnabled := ReadBool('Performance','ProfilingMemSupport',false);
-          profPrfOutputFile := ReadString('Output','PrfOutputFilename','$(ModulePath)');
+          profProcSize           := LIni.ReadInteger('Procedures','ProcSize',4);
+          profCompressTicks      := LIni.ReadBool('Performance','CompressTicks',false);
+          profCompressThreads    := LIni.ReadBool('Performance','CompressThreads',false);
+          profProfilingAutostart := LIni.ReadBool('Performance','ProfilingAutostart',true);
+          profProfilingMemoryEnabled := LIni.ReadBool('Performance','ProfilingMemSupport',false);
+          profPrfOutputFile := LIni.ReadString('Output','PrfOutputFilename','$(ModulePath)');
           profPrfOutputFile := ResolvePrfRuntimePlaceholders(profPrfOutputFile);
           prfDisabled            := false;
         end;
       end;
-      Free;
+    finally
+      LIni.Free;
     end;
   end;
 end; { ReadIncSettings }
@@ -619,7 +622,9 @@ begin
 end; { Finalize }
 
 procedure ProfilerTerminate;
-var i : integer;
+var
+  i: integer;
+  LItem: TThreadInformation;
 begin
   if not prfInitialized then Exit;
   ProfilerStop;
@@ -631,10 +636,9 @@ begin
   WriteCardinal(prfThreadsInfo.count);
   for i := 0 to prfThreadsInfo.count-1 do
   begin
-    with prfThreadsInfo[i] as TThreadInformation do begin
-      WriteCardinal(ID);
-      WriteUtf8String(Name);
-    end;
+    LItem := TThreadInformation(prfThreadsInfo[i]);
+    WriteCardinal(LItem.ID);
+    WriteUtf8String(LItem.Name);
   end;
   WriteInt(PR_END_THREADINFO);
 

--- a/include/GpProf.pas
+++ b/include/GpProf.pas
@@ -19,6 +19,26 @@ interface
 {$WARN SYMBOL_PLATFORM OFF}
 {$WARN SYMBOL_DEPRECATED OFF}
 
+{$IF CompilerVersion > 19}
+  {$DEFINE HAS_NAME_THREAD_FOR_DEBUGGING}
+  {$DEFINE HAS_THREAD_ID_TYPE}
+{$IFEND}
+
+(******************************************************************************)
+
+{$IFNDEF HAS_THREAD_ID_TYPE}
+type
+  TThreadID = Cardinal;
+{$ENDIF}
+
+{$IF CompilerVersion < 19}
+type
+  // fix Delphi 2007 invalid type declarations
+  // https://blog.dummzeuch.de/2018/09/08/nativeint-nativeuint-type-in-various-delphi-versions/
+  NativeInt = Integer;
+  NativeUInt = Cardinal;
+{$IFEND}
+
 type
   /// <summary>
   /// Marker interface for a measure point scope. upon destruction, the scope will be stored.
@@ -39,8 +59,13 @@ procedure ProfilerExitMP(const aMeasurePointId: UTF8String);
 function CreateMeasurePointScope(const aMeasurePointId: string): IMeasurePointScope;
 
 procedure ProfilerTerminate;
+
+{$IFDEF UNICODE}
 procedure NameThreadForDebugging(const AThreadName: AnsiString; AThreadID: TThreadID = TThreadID(-1)); overload; inline;
 procedure NameThreadForDebugging(const AThreadName: string; AThreadID: TThreadID = TThreadID(-1)); overload;
+{$ELSE}
+procedure NameThreadForDebugging(const AThreadName: string; AThreadID: TThreadID = TThreadID(-1));
+{$ENDIF}
 
 implementation
 
@@ -362,15 +387,52 @@ begin
   Result := Copy(fName,1,Length(fName)-Length(ExtractFileExt(fName)))+'.'+newExt;
 end; { CombineNames }
 
+{$IFDEF UNICODE}
 procedure NameThreadForDebugging(const AThreadName: AnsiString; AThreadID: TThreadID);
 begin
   NameThreadForDebugging(string(aThreadName), aThreadID);
 end; { NameThreadForDebugging }
+{$ENDIF}
+
+{$IFNDEF HAS_NAME_THREAD_FOR_DEBUGGING}
+procedure SetCurrentThreadName(const AName: AnsiString; AThreadID: DWORD);
+type
+  {$A8}
+  TThreadNameInfo = record
+    dwType     : DWORD;   // must be 0x1000
+    szName     : LPCSTR;  // pointer to name (in user addr space)
+    dwThreadID : DWORD;   // thread ID (-1 indicates caller thread)
+    dwFlags    : DWORD;   // reserved for future use, must be zero
+  end;
+const
+  MS_VC_EXCEPTION: DWORD = $406D1388;
+var
+  LInfo: TThreadNameInfo;
+begin
+  // This code is extremely strange, but it's the documented way of doing it
+  // https://learn.microsoft.com/en-us/visualstudio/debugger/tips-for-debugging-threads
+
+  LInfo.dwType     := $1000;
+  LInfo.szName     := PAnsiChar(AName);
+  LInfo.dwThreadID := AThreadID;
+  LInfo.dwFlags    := 0;
+
+  try
+    RaiseException(MS_VC_EXCEPTION, 0, SizeOf(LInfo) div SizeOf(ULONG_PTR), @LInfo);
+  except
+    // do nothing
+  end;
+end;
+{$ENDIF}
 
 procedure NameThreadForDebugging(const AThreadName: string; AThreadID: TThreadID);
 var LEntry : TThreadInformation;
 begin
+  {$IFDEF HAS_NAME_THREAD_FOR_DEBUGGING}
   TThread.NameThreadForDebugging(aThreadName, aThreadId);
+  {$ELSE}
+  SetCurrentThreadName(AnsiString(aThreadName), aThreadId);
+  {$ENDIF}
   if not prfDisabled then
   begin
     LEntry := TThreadInformation.Create;
@@ -400,27 +462,27 @@ end; { TThreadList.Destroy }
 
 function TThreadList.Remap(const aThreadId: Cardinal): integer;
 var
-  remap   : Cardinal;
-  insert  : Cardinal;
-  tmpItems: PTLElements;
+  LRemap   : Cardinal;
+  LInsert  : Cardinal;
+  LTmpItems: PTLElements;
 begin
   if aThreadId = tlLast then
     Result := tlLastR
-  else if not Search(aThreadId, remap, insert) then begin
+  else if not Search(aThreadId, LRemap, LInsert) then begin
     // reallocate tlItems
-    GetMem(tmpItems, SizeOf(TTLEl)*(tlCount+1));
+    GetMem(LTmpItems, SizeOf(TTLEl)*(tlCount+1));
     if tlItems <> nil then begin
-      Move(tlItems^, tmpItems^, Sizeof(TTLEl)*tlCount);
+      Move(tlItems^, LTmpItems^, Sizeof(TTLEl)*tlCount);
       FreeMem(tlItems);
     end;
-    tlItems := tmpItems;
+    tlItems := LTmpItems;
     // get new remap number
     Inc(tlRemap);
     if byte(tlRemap) = 0 then Inc(tlRemap);
     // insert new element
-    if insert < tlCount then
-      Move(tlItems^[insert], tlItems^[insert + 1], (tlCount-insert)*SizeOf(TTLEl));
-    with tlItems^[Insert] do begin
+    if LInsert < tlCount then
+      Move(tlItems^[LInsert], tlItems^[LInsert + 1], (tlCount-LInsert)*SizeOf(TTLEl));
+    with tlItems^[LInsert] do begin
       tleThread := aThreadId;
       tleRemap  := tlRemap;
     end;
@@ -431,8 +493,8 @@ begin
   end
   else begin
     tlLast  := aThreadId;
-    tlLastR := remap;
-    Result  := remap;
+    tlLastR := LRemap;
+    Result  := LRemap;
   end;
 end; { TThreadList.Remap }
 

--- a/include/GpProf.pas
+++ b/include/GpProf.pas
@@ -33,11 +33,8 @@ procedure ProfilerStartThread;
 procedure ProfilerEnterProc(const aProcID: Cardinal);
 procedure ProfilerExitProc(const aProcID: Cardinal);
 
-procedure ProfilerEnterMP(const aMeasurePointId: UTF8String); overload; inline;
-procedure ProfilerEnterMP(const aMeasurePointId: PUTF8Char; const aMeasurePointIdLen: Integer); overload;
-
-procedure ProfilerExitMP(const aMeasurePointId: UTF8String); overload; inline;
-procedure ProfilerExitMP(const aMeasurePointId: PUTF8Char; const aMeasurePointIdLen: Integer); overload;
+procedure ProfilerEnterMP(const aMeasurePointId: UTF8String);
+procedure ProfilerExitMP(const aMeasurePointId: UTF8String);
 
 function CreateMeasurePointScope(const aMeasurePointId: string): IMeasurePointScope;
 
@@ -231,13 +228,6 @@ begin
   WriteCardinal(Length(aValue));
   if Length(aValue)>0 then
     Transmit(aValue[1], Length(aValue));
-end;
-
-procedure WriteRawData(const aValue; const aSize: Integer); inline;
-begin
-  WriteCardinal(aSize);
-  if aSize>0 then
-    Transmit(aValue, aSize);
 end;
 
 procedure WriteTicks(ticks: TLargeInteger);
@@ -652,11 +642,6 @@ begin
 end; { ProfilerTerminate }
 
 procedure ProfilerEnterMP(const aMeasurePointId: UTF8String);
-begin
-  ProfilerEnterMP(PUTF8Char(aMeasurePointId), Length(aMeasurePointId));
-end;
-
-procedure ProfilerEnterMP(const aMeasurePointId: PUTF8Char; const aMeasurePointIdLen: Integer);
 var
   ct : Cardinal;
   cnt: TLargeInteger;
@@ -671,7 +656,7 @@ begin
       FlushCounter;
       WriteTag(PR_ENTER_MP);
       WriteThread(ct);
-      WriteRawData(aMeasurePointId^,aMeasurePointIdLen);
+      WriteUtf8String(aMeasurePointId);
       WriteTicks(Cnt);
       if profProfilingMemoryEnabled then
         WriteMemWorkingSize();
@@ -681,11 +666,6 @@ begin
 end;
 
 procedure ProfilerExitMP(const aMeasurePointId: UTF8String);
-begin
-  ProfilerExitMP(PUTF8Char(aMeasurePointId), Length(aMeasurePointId));
-end;
-
-procedure ProfilerExitMP(const aMeasurePointId: PUTF8Char; const aMeasurePointIdLen: Integer);
 var
   ct : Cardinal;
   cnt: TLargeInteger;
@@ -700,7 +680,7 @@ begin
       FlushCounter;
       WriteTag(PR_EXIT_MP);
       WriteThread(ct);
-      WriteRawData(aMeasurePointId^,aMeasurePointIdLen);
+      WriteUtf8String(aMeasurePointId);
       WriteTicks(Cnt);
       if profProfilingMemoryEnabled then
         WriteMemWorkingSize();

--- a/include/GpProf.pas
+++ b/include/GpProf.pas
@@ -12,14 +12,12 @@
     - Error is reported if <module>.gpi or <module>.gpd file is not found.
 *)
 
-unit gpprof;
+unit GpProf;
 
 interface
 
 {$WARN SYMBOL_PLATFORM OFF}
 {$WARN SYMBOL_DEPRECATED OFF}
-
-uses System.Classes;
 
 type
   /// <summary>
@@ -31,25 +29,32 @@ type
 procedure ProfilerStart;
 procedure ProfilerStop;
 procedure ProfilerStartThread;
+
 procedure ProfilerEnterProc(const aProcID: Cardinal);
 procedure ProfilerExitProc(const aProcID: Cardinal);
-function CreateMeasurePointScope(const aMeasurePointId : String): IMeasurePointScope;
+
+procedure ProfilerEnterMP(const aMeasurePointId: UTF8String); overload; inline;
+procedure ProfilerEnterMP(const aMeasurePointId: PUTF8Char; const aMeasurePointIdLen: Integer); overload;
+
+procedure ProfilerExitMP(const aMeasurePointId: UTF8String); overload; inline;
+procedure ProfilerExitMP(const aMeasurePointId: PUTF8Char; const aMeasurePointIdLen: Integer); overload;
+
+function CreateMeasurePointScope(const aMeasurePointId: string): IMeasurePointScope;
 
 procedure ProfilerTerminate;
-procedure NameThreadForDebugging(const AThreadName: AnsiString; AThreadID: TThreadID = TThreadID(-1)); overload;
+procedure NameThreadForDebugging(const AThreadName: AnsiString; AThreadID: TThreadID = TThreadID(-1)); overload; inline;
 procedure NameThreadForDebugging(const AThreadName: string; AThreadID: TThreadID = TThreadID(-1)); overload;
 
 implementation
 
 uses
-  System.Generics.Collections,
   Windows,
-  psAPI,
+  Classes,
+  Contnrs,
   SysUtils,
   IniFiles,
   GpProfH,
-
-  gpprofCommon;
+  GpProfCommon;
 
 const
   BUF_SIZE = 64 * 1024; //64*1024;
@@ -57,9 +62,9 @@ const
 type
   TMeasurePointScope = class(TInterfacedObject, IMeasurePointScope)
   private
-    fMeasurePointId : String;
+    fMeasurePointId : UTF8String;
   public
-    constructor Create(const aMeasurePointId : String);
+    constructor Create(const aMeasurePointId : UTF8String);
     destructor Destroy; override;
   end;
 
@@ -88,22 +93,22 @@ type
 
   TThreadInformation = class
     ID : cardinal;
-    Name : ansistring;
+    Name : UTF8String;
   end;
 
-  TThreadInformationList = TObjectList<TThreadInformation>;
+  TThreadInformationList = TObjectList;
 
 var
   prfFile        : THandle;
   prfBuf         : pointer;
   prfBufOffs     : integer;
   prfLock        : TRTLCriticalSection;
-  prfFreq        : int64;
-  prfCounter     : int64;
+  prfFreq        : TLargeInteger;
+  prfCounter     : TLargeInteger;
   prfModuleName  : string;
   prfName        : string;
   prfRunning     : boolean;
-  prfLastTick    : int64;
+  prfLastTick    : TLargeInteger;
   prfOnlyThread  : Cardinal;
   prfThreads     : TThreadList;
   prfThreadsInfo : TThreadInformationList;
@@ -129,7 +134,7 @@ begin
   FillChar(prfBuf^, BUF_SIZE, 0);
 end; { FlushFile }
 
-function OffsetPtr(ptr: Pointer; offset: NativeUInt): Pointer;
+function OffsetPtr(ptr: Pointer; offset: NativeUInt): Pointer; inline;
 begin
   Result := Pointer(NativeUInt(ptr) + offset);
 end; { OffsetPtr }
@@ -190,20 +195,52 @@ begin
   lMemUsed := GetMemWorkingSize();
   Transmit(lMemUsed, sizeof(Cardinal));
 end;
-procedure WriteInt   (int: integer);  begin Transmit(int, SizeOf(integer)); end;
-procedure WriteCardinal   (value: Cardinal);  begin Transmit(value, SizeOf(Cardinal)); end;
-procedure WriteTag   (tag: byte);     begin Transmit(tag, SizeOf(byte)); end;
-procedure WriteID    (id: integer);   begin Transmit(id, profProcSize); end;
-procedure WriteGuid    (guid: TGUID);   begin Transmit(guid, SizeOf(TGUID)); end;
-procedure WriteBool  (bool: boolean); begin Transmit(bool, 1); end;
-procedure WriteAnsiString  (const value: ansistring);
+
+procedure WriteInt(int: integer); inline;
 begin
-  WriteCardinal(Length(value));
-  if Length(Value)>0 then
-    Transmit(value[1], Length(value));
+  Transmit(int, SizeOf(integer));
 end;
 
-procedure WriteTicks(ticks: int64);
+procedure WriteCardinal(value: Cardinal); inline;
+begin
+  Transmit(value, SizeOf(Cardinal));
+end;
+
+procedure WriteTag(tag: byte); inline;
+begin
+  Transmit(tag, SizeOf(byte));
+end;
+
+procedure WriteProcID(id: integer); inline;
+begin
+  Transmit(id, profProcSize);
+end;
+
+procedure WriteGuid(const guid: TGUID); inline;
+begin
+  Transmit(guid, SizeOf(TGUID));
+end;
+
+procedure WriteBool(bool: boolean); inline;
+begin
+  Transmit(bool, 1);
+end;
+
+procedure WriteUtf8String(const aValue: UTF8String); inline;
+begin
+  WriteCardinal(Length(aValue));
+  if Length(aValue)>0 then
+    Transmit(aValue[1], Length(aValue));
+end;
+
+procedure WriteRawData(const aValue; const aSize: Integer); inline;
+begin
+  WriteCardinal(aSize);
+  if aSize>0 then
+    Transmit(aValue, aSize);
+end;
+
+procedure WriteTicks(ticks: TLargeInteger);
 type
   TTick = array [1..8] of Byte;
 var
@@ -242,7 +279,7 @@ begin
   end;
 end; { WriteThread }
 
-procedure FlushCounter;
+procedure FlushCounter; inline;
 begin
   if prfCounter <> 0 then begin
     WriteTicks(prfCounter);
@@ -250,10 +287,10 @@ begin
   end;
 end; { FlushCounter }
 
-procedure profilerEnterProc(const aProcID : Cardinal);
+procedure ProfilerEnterProc(const aProcID : Cardinal);
 var
   ct : Cardinal;
-  cnt: int64;
+  cnt: TLargeInteger;
 begin
   QueryPerformanceCounter(cnt);
   ct := GetCurrentThreadID;
@@ -265,7 +302,7 @@ begin
       FlushCounter;
       WriteTag(PR_ENTERPROC);
       WriteThread(ct);
-      WriteID(aProcID);
+      WriteProcID(aProcID);
       WriteTicks(cnt);
       if profProfilingMemoryEnabled then
         WriteMemWorkingSize();
@@ -289,7 +326,7 @@ begin
       FlushCounter;
       WriteTag(PR_EXITPROC);
       WriteThread(ct);
-      WriteID(aProcID);
+      WriteProcID(aProcID);
       WriteTicks(Cnt);
       if profProfilingMemoryEnabled then
         WriteMemWorkingSize();
@@ -300,7 +337,7 @@ end; { ProfilerExitProc }
 
 function CreateMeasurePointScope(const aMeasurePointId : String): IMeasurePointScope;
 begin
-  result := TMeasurePointScope.Create(aMeasurePointId);
+  result := TMeasurePointScope.Create(UTF8Encode(aMeasurePointId));
 end;
 
 procedure ProfilerStart;
@@ -330,18 +367,17 @@ begin
   finally LeaveCriticalSection(prfLock); end;
 end; { ProfilerStartThread }
 
-function CombineNames(fName, newExt: string): string;
+function CombineNames(const fName, newExt: string): string;
 begin
   Result := Copy(fName,1,Length(fName)-Length(ExtractFileExt(fName)))+'.'+newExt;
 end; { CombineNames }
 
-procedure NameThreadForDebugging(const AThreadName: AnsiString; AThreadID: TThreadID = TThreadID(-1)); overload;
+procedure NameThreadForDebugging(const AThreadName: AnsiString; AThreadID: TThreadID);
 begin
   NameThreadForDebugging(string(aThreadName), aThreadID);
 end; { NameThreadForDebugging }
 
-
-procedure NameThreadForDebugging(const AThreadName: string; AThreadID: TThreadID = TThreadID(-1)); overload;
+procedure NameThreadForDebugging(const AThreadName: string; AThreadID: TThreadID);
 var LEntry : TThreadInformation;
 begin
   TThread.NameThreadForDebugging(aThreadName, aThreadId);
@@ -349,11 +385,10 @@ begin
   begin
     LEntry := TThreadInformation.Create;
     LEntry.ID := AThreadId;
-    LEntry.Name := utf8Encode(AThreadName);
+    LEntry.Name := UTF8Encode(AThreadName);
     prfThreadsInfo.Add(LEntry);
   end;
 end; { NameThreadForDebugging }
-
 
 { TThreadList }
 
@@ -493,7 +528,6 @@ procedure Initialize();
 var
   LErrorPath : string;
 begin
-  ReadIncSettings;
   try
     ReadIncSettings;
     if not prfDisabled then begin
@@ -501,7 +535,7 @@ begin
       prfCounter          := 0;
       prfOnlyThread       := 0;
       prfThreads          := TThreadList.Create;
-      prfThreadsInfo      := TThreadInformationList.Create();
+      prfThreadsInfo      := TThreadInformationList.Create;
       prfMaxThreadNum     := 256;
       prfThreadBytes      := 1;
       prfLastTick         := -1;
@@ -607,74 +641,84 @@ begin
   WriteCardinal(prfThreadsInfo.count);
   for i := 0 to prfThreadsInfo.count-1 do
   begin
-    WriteCardinal(prfThreadsInfo[i].ID);
-    WriteAnsiString(prfThreadsInfo[i].Name);
+    with prfThreadsInfo[i] as TThreadInformation do begin
+      WriteCardinal(ID);
+      WriteUtf8String(Name);
+    end;
   end;
   WriteInt(PR_END_THREADINFO);
 
   Finalize;
-
 end; { ProfilerTerminate }
 
+procedure ProfilerEnterMP(const aMeasurePointId: UTF8String);
+begin
+  ProfilerEnterMP(PUTF8Char(aMeasurePointId), Length(aMeasurePointId));
+end;
+
+procedure ProfilerEnterMP(const aMeasurePointId: PUTF8Char; const aMeasurePointIdLen: Integer);
+var
+  ct : Cardinal;
+  cnt: TLargeInteger;
+begin
+  QueryPerformanceCounter(cnt);
+  ct := GetCurrentThreadID;
+{$B+}
+  if prfRunning and ((prfOnlyThread = 0) or (prfOnlyThread = ct)) then begin
+{$B-}
+    EnterCriticalSection(prfLock);
+    try
+      FlushCounter;
+      WriteTag(PR_ENTER_MP);
+      WriteThread(ct);
+      WriteRawData(aMeasurePointId^,aMeasurePointIdLen);
+      WriteTicks(Cnt);
+      if profProfilingMemoryEnabled then
+        WriteMemWorkingSize();
+      QueryPerformanceCounter(prfCounter);
+    finally LeaveCriticalSection(prfLock); end;
+  end;
+end;
+
+procedure ProfilerExitMP(const aMeasurePointId: UTF8String);
+begin
+  ProfilerExitMP(PUTF8Char(aMeasurePointId), Length(aMeasurePointId));
+end;
+
+procedure ProfilerExitMP(const aMeasurePointId: PUTF8Char; const aMeasurePointIdLen: Integer);
+var
+  ct : Cardinal;
+  cnt: TLargeInteger;
+begin
+  QueryPerformanceCounter(Cnt);
+  ct := GetCurrentThreadID;
+{$B+}
+  if prfRunning and ((prfOnlyThread = 0) or (prfOnlyThread = ct)) then begin
+{$B-}
+    EnterCriticalSection(prfLock);
+    try
+      FlushCounter;
+      WriteTag(PR_EXIT_MP);
+      WriteThread(ct);
+      WriteRawData(aMeasurePointId^,aMeasurePointIdLen);
+      WriteTicks(Cnt);
+      if profProfilingMemoryEnabled then
+        WriteMemWorkingSize();
+      QueryPerformanceCounter(prfCounter);
+    finally LeaveCriticalSection(prfLock); end;
+  end;
+end;
 
 { TMeasurePointScope }
 
-constructor TMeasurePointScope.Create(const aMeasurePointId: String);
-
-  procedure ProfilerEnterMP(const aMeasurePointId : String);
-  var
-    ct : Cardinal;
-    cnt: int64;
-  begin
-    QueryPerformanceCounter(cnt);
-    ct := GetCurrentThreadID;
-  {$B+}
-    if prfRunning and ((prfOnlyThread = 0) or (prfOnlyThread = ct)) then begin
-  {$B-}
-      EnterCriticalSection(prfLock);
-      try
-        FlushCounter;
-        WriteTag(PR_ENTER_MP);
-        WriteThread(ct);
-        WriteAnsiString(utf8Encode(aMeasurePointId));
-        WriteTicks(Cnt);
-        if profProfilingMemoryEnabled then
-          WriteMemWorkingSize();
-        QueryPerformanceCounter(prfCounter);
-      finally LeaveCriticalSection(prfLock); end;
-    end;
-  end;
-
+constructor TMeasurePointScope.Create(const aMeasurePointId: UTF8String);
 begin
+  inherited Create;
   fMeasurePointId := aMeasurePointId;
   ProfilerEnterMP(fMeasurePointId);
 end;
 
 destructor TMeasurePointScope.Destroy;
-  procedure ProfilerExitMP(const aMeasurePointId : String);
-  var
-    ct : Cardinal;
-    cnt: TLargeinteger;
-  begin
-    QueryPerformanceCounter(Cnt);
-    ct := GetCurrentThreadID;
-  {$B+}
-    if prfRunning and ((prfOnlyThread = 0) or (prfOnlyThread = ct)) then begin
-  {$B-}
-      EnterCriticalSection(prfLock);
-      try
-        FlushCounter;
-        WriteTag(PR_EXIT_MP);
-        WriteThread(ct);
-        WriteAnsiString(utf8Encode(aMeasurePointId));
-        WriteTicks(Cnt);
-        if profProfilingMemoryEnabled then
-          WriteMemWorkingSize();
-        QueryPerformanceCounter(prfCounter);
-      finally LeaveCriticalSection(prfLock); end;
-    end;
-  end;
-
 begin
   ProfilerExitMP(fMeasurePointId);
   inherited;
@@ -691,7 +735,9 @@ initialization
     prfInitialized := true;
     gpprof.NameThreadForDebugging('Main Application Thread', MainThreadID);
   end;
+
 finalization
   ProfilerTerminate;
+
 end.
 

--- a/include/gpprofCommon.pas
+++ b/include/gpprofCommon.pas
@@ -2,13 +2,15 @@ unit GpProfCommon;
 
 interface
 
-  function ResolvePrfRuntimePlaceholders(const aFilenameWithPh: string): string;
+{$IF CompilerVersion > 19}
+  {$DEFINE HAS_UINT_TO_STR}
+{$IFEND}
 
-
+function ResolvePrfRuntimePlaceholders(const aFilenameWithPh: string): string;
 
 implementation
 
-uses windows, strUtils,sysutils,TlHelp32;
+uses Windows, StrUtils, SysUtils, TlHelp32;
 
 function HasPrfPlaceholder(var aText: string; const aKey: string): boolean;
 var
@@ -17,7 +19,6 @@ begin
   lPosition := PosEx(aKey, aText);
   result := lPosition > 0;
 end;
-
 
 procedure ReplacePrfPlaceholders(var aText: string; const aKey, aNewValue: string);
 var
@@ -30,7 +31,6 @@ begin
     lPosition := PosEx(aKey, aText);
   end;
 end;
-
 
 function GetProcessNameByID(const aPidToBeFound: Cardinal): string;
 var
@@ -58,7 +58,7 @@ begin
    Result := PName;
 end;
 
-function getCurrentModulePath(): string;
+function GetCurrentModulePath(): string;
 var
   buf: array [0..256] of char;
 begin
@@ -66,25 +66,30 @@ begin
   result := buf;
 end;
 
-function getCurrentModuleName(): string;
+function GetCurrentModuleName(): string;
 begin
-  result := getCurrentModulePath();
+  result := GetCurrentModulePath();
   result := ChangeFileExt(ExtractFileName(result),'');
 end;
+
+{$IFNDEF HAS_UINT_TO_STR}
+function UIntToStr(const aValue: Cardinal): string;
+begin
+  result := IntToStr(Int64(aValue));
+end;
+{$ENDIF}
 
 function ResolvePrfRuntimePlaceholders(const aFilenameWithPh: string): string;
 begin
   result := aFilenameWithPh;
   if HasPrfPlaceholder(result,'$(ProcessID)') then
-    ReplacePrfPlaceholders(result,'$(ProcessID)',  UIntToStr (GetCurrentProcessID()));
+    ReplacePrfPlaceholders(result,'$(ProcessID)', UIntToStr(GetCurrentProcessID()));
   if HasPrfPlaceholder(result,'$(ProcessName)') then
     ReplacePrfPlaceholders(result,'$(ProcessName)', GetProcessNameByID(GetCurrentProcessID()));
   if HasPrfPlaceholder(result,'$(ModuleName)') then
-    ReplacePrfPlaceholders(result,'$(ModuleName)', getCurrentModuleName());
+    ReplacePrfPlaceholders(result,'$(ModuleName)', GetCurrentModuleName());
   if HasPrfPlaceholder(result,'$(ModulePath)') then
-    ReplacePrfPlaceholders(result,'$(ModulePath)', ChangeFileExt(getCurrentModulePath(),''));
-
-
+    ReplacePrfPlaceholders(result,'$(ModulePath)', ChangeFileExt(GetCurrentModulePath(),''));
 end;
 
 end.


### PR DESCRIPTION
- declare missing `TThreadID` type
- fix incorrect declarations of `NativeUInt` and `NativeInt` (Delphi 2007 and Delphi 7 bug)
- implement missing `UIntToStr` function
- implement missing `TThread.NameThreadForDebugging` function
- fix error caused by identical names of the `remap` variable and the method in `TThreadList.Remap`