### PR TITLE
Properly clear StatusBar, Sources, and Trees

### DIFF
--- a/source/ui/gppMain.pas
+++ b/source/ui/gppMain.pas
@@ -425,6 +425,7 @@ begin
   Enabled := False;
   DisablePC;
   lLastSelectionStream := nil;
+  ClearSource;
   if assigned(openProject) then
   begin
     lLastSelectionStream := TMemoryStream.Create();
@@ -437,7 +438,7 @@ begin
     FreeAndNil(openProject);
     InitProgressBar(self,self.ApplicationTaskbar, 'Parsing units...', true, false);
     SetProgressBarOverlayHint('Parsing units...');
-    FInstrumentationFrame.FillUnitTree(true, false); // clear all listboxes
+    FInstrumentationFrame.ClearAll; // clear all listboxes
     openProject := TProject.Create(aProject, TSessionData.selectedDelphi);
     TSessionData.CurrentProjectName := aProject;
     RebuildDefines;
@@ -1682,7 +1683,8 @@ begin
       if focusOn >= sourceCodeEdit.Lines.Count then focusOn := sourceCodeEdit.Lines.Count-1;
       sourceCodeEdit.TopLine := focusOn+1;
       StatusPanel0(fileName,false);
-    end;
+    end else
+      ClearSource;
   except
     sourceCodeEdit.Lines.Clear;
   end;
@@ -1692,7 +1694,7 @@ procedure TfrmMain.ClearSource;
 begin
   sourceCodeEdit.Lines.Clear;
   loadedSource := '';
-  StatusPanel0('',true);
+  StatusPanel0('',false);
 end; { TfrmMain.ClearSource }
 
 procedure TfrmMain.actExportProfileExecute(Sender: TObject);
@@ -1739,10 +1741,8 @@ end;
 
 procedure TfrmMain.StatusPanel0(const msg: string; const beep: boolean);
 begin
-  if (msg <> '') then begin
-    StatusBar.Panels[0].Text := msg;
-    if beep then MessageBeep($FFFFFFFF);
-  end;
+  StatusBar.Panels[0].Text := msg;
+  if beep then MessageBeep($FFFFFFFF);
 end;
 
 procedure TfrmMain.ShowError(const Msg : string);

--- a/source/ui/gppmain.FrameInstrumentation.pas
+++ b/source/ui/gppmain.FrameInstrumentation.pas
@@ -84,6 +84,7 @@ type
 
     procedure DisablePC();
     procedure EnablePC;
+    procedure ClearAll;
     procedure ReloadSource;
     procedure ChangeClassSelectionWithoutEvent(const anIndex : integer);
     function  GetSelectedUnitNode(): pVirtualNode;
@@ -305,6 +306,13 @@ begin
     RecreateClasses(false, node);
     clbClassesClick(vstSelectClasses);
   end;
+end;
+
+procedure TfrmMainInstrumentation.ClearAll;
+begin
+  fVstSelectUnitTools.Clear;
+  fVstSelectClassTools.Clear;
+  fVstSelectProcTools.Clear;
 end;
 
 procedure TfrmMainInstrumentation.ClickProcs(index: integer; recreateCl: boolean);


### PR DESCRIPTION
- on Rescan project
- on Switch between projects
- when navigating between units in tree mode when the user clicks on a folder