### PR TITLE
Fix counters overflow for Performance and Memory Analysis

### DIFF
--- a/include/GpProf.pas
+++ b/include/GpProf.pas
@@ -150,22 +150,21 @@ end; { Transmit }
 
 function GetMemWorkingSize() : Cardinal;
 var
-  MemoryManagerState: TMemoryManagerState;
-  SmallBlockState: TSmallBlockTypeState;
   i: Integer;
+  LState: TMemoryManagerState;
+  LSmallBlocks: TSmallBlockTypeStates;
+  LSmallBlock: ^TSmallBlockTypeState;
 begin
-  GetMemoryManagerState( MemoryManagerState );
   Result := 0;
-  for i := low(MemoryManagerState.SmallBlockTypeStates) to
-        high(MemoryManagerState.SmallBlockTypeStates) do
-    begin
-    SmallBlockState := MemoryManagerState.SmallBlockTypeStates[i];
-    Inc(Result,
-    SmallBlockState.AllocatedBlockCount*SmallBlockState.UseableBlockSize);
-    end;
-
-  Inc(Result, MemoryManagerState.TotalAllocatedMediumBlockSize);
-  Inc(Result, MemoryManagerState.TotalAllocatedLargeBlockSize);
+  GetMemoryManagerState(LState);
+  LSmallBlocks := LState.SmallBlockTypeStates;
+  for i := Low(LSmallBlocks) to High(LSmallBlocks) do
+  begin
+    LSmallBlock := @LSmallBlocks[i];
+    Inc(Result,LSmallBlock.AllocatedBlockCount*LSmallBlock.UseableBlockSize);
+  end;
+  Inc(Result,LState.TotalAllocatedMediumBlockSize);
+  Inc(Result,LState.TotalAllocatedLargeBlockSize);
 end;
 
 procedure WriteMemWorkingSize();

--- a/source/model/profilingResultParser/gppResults.procs.pas
+++ b/source/model/profilingResultParser/gppResults.procs.pas
@@ -16,7 +16,7 @@ type
     ppStartTime   : int64;
     ppTotalTime   : int64;
     ppChildTime   : int64;
-    ppTotalMem    : Cardinal;
+    ppTotalMem    : int64;
   public
     constructor Create(const aThreadID, aProcID: Cardinal);
     destructor  Destroy; override;
@@ -30,21 +30,20 @@ type
     property StartTime : int64 read ppStartTime;
     property TotalTime : int64 read ppTotalTime;
     property ChildTime : int64 read ppChildTime write ppChildTime;
-    property TotalMem : Cardinal read ppTotalMem;
+    property TotalMem  : int64 read ppTotalMem;
 
   end;
 
 
   TProcWithMemProxy = class(TProcProxy)
   private
-    ppStartMem    : Cardinal;
-    ppEndMem    : Cardinal;
-  protected
+    ppStartMem : int64;
+    ppEndMem   : int64;
   public
     procedure Start(const pkt: TResPacket; const memPkt: TResMemPacket);  override;
     procedure Stop(var pkt: TResPacket; const memPkt: TResMemPacket); override;
-    property StartMem : Cardinal read ppStartMem write ppStartMem;
-    property EndMem : Cardinal read ppEndMem write ppEndMem;
+    property StartMem : int64 read ppStartMem write ppStartMem;
+    property EndMem : int64 read ppEndMem write ppEndMem;
   end;
 
   TActiveProcList = class

--- a/source/model/profilingResultParser/gppResults.types.pas
+++ b/source/model/profilingResultParser/gppResults.types.pas
@@ -21,7 +21,7 @@ type
     peProcTimeMax  : array {thread} of uint64;   // 0 = unused
     peProcTimeAvg  : array {thread} of uint64;   // 0 = unused
     peProcChildTime: array {thread} of uint64;   // 0 = sum
-    peProcMem      : array of Cardinal;
+    peProcMem      : array of int64;
     peProcCnt      : array {thread} of Cardinal; // 0 = sum
     peCurrentCallDepth : array {thread} of integer; // 0 = unused
 
@@ -56,7 +56,7 @@ type
   end;
 
   TResMemPacket = record
-    rpMemWorkingSize : Cardinal;
+    rpMemWorkingSize : int64;
   end;
 
 const

--- a/source/model/profilingResultParser/gppresults.pas
+++ b/source/model/profilingResultParser/gppresults.pas
@@ -23,7 +23,7 @@ type
   public
     teThread     : integer;
     teName       : AnsiString;
-    teTotalTime  : int64;
+    teTotalTime  : uint64;
     teTotalCnt   : integer;
     teActiveProcs: TActiveProcList;
     teTotalMem   : int64;
@@ -38,7 +38,7 @@ type
   public
     ueName     : AnsiString;
     ueQual     : AnsiString;
-    ueTotalTime: array {thread} of int64;   // 0 = sum
+    ueTotalTime: array {thread} of uint64;   // 0 = sum
     ueTotalCnt : array {thread} of integer; // 0 = sum
     ueTotalMem: array {thread} of int64;   // 0 = sum
 
@@ -53,7 +53,7 @@ type
     ceName     : AnsiString;
     ceUID      : integer;
     ceFirstLn  : integer;
-    ceTotalTime: array {thread} of int64;   // 0 = sum
+    ceTotalTime: array {thread} of uint64;   // 0 = sum
     ceTotalCnt : array {thread} of integer; // 0 = sum
     ceTotalMem: array {thread} of int64;   // 0 = sum
 
@@ -121,6 +121,7 @@ type
     procedure   WriteTag(tag: byte);
     procedure   WriteInt(int: integer);
     procedure   WriteInt64(i64: int64);
+    procedure   WriteUInt64(u64: uint64);
     procedure   WriteString(str: ansistring);
     procedure   CheckTag(tag: byte);
     function    ReadPacket(var pkt: TResPacket; var pktMem: TResMemPacket): boolean;
@@ -307,6 +308,7 @@ end; { TResults.ReadString }
 procedure TResults.WriteTag  (tag: byte);    begin resFile.BlockWriteUnsafe(tag,SizeOf(byte)); end;
 procedure TResults.WriteInt  (int: integer); begin resFile.BlockWriteUnsafe(int,SizeOf(integer)); end;
 procedure TResults.WriteInt64(i64: int64);   begin resFile.BlockWriteUnsafe(i64,SizeOf(int64)); end;
+procedure TResults.WriteUInt64(u64: uint64);   begin resFile.BlockWriteUnsafe(u64,SizeOf(uint64)); end;
 
 procedure TResults.WriteString(str: ansistring);
 begin
@@ -1081,7 +1083,7 @@ begin
         incrementAndTriggerProgress();
         WriteInt(teThread);
         WriteString(teName);
-        WriteInt64(teTotalTime);
+        WriteUInt64(teTotalTime);
         WriteInt(teTotalCnt);
         WriteInt64(teTotalMem);
       end;
@@ -1094,7 +1096,7 @@ begin
         WriteString(ueQual);
         WriteInt(High(ueTotalTime)-Low(ueTotalTime)+1);
         for j := Low(ueTotalTime) to High(ueTotalTime) do
-          WriteInt64(ueTotalTime[j]);
+          WriteUInt64(ueTotalTime[j]);
         WriteInt(High(ueTotalCnt)-Low(ueTotalCnt)+1);
         for j := Low(ueTotalCnt) to High(ueTotalCnt) do
           WriteInt(ueTotalCnt[j]);
@@ -1113,7 +1115,7 @@ begin
         WriteInt(ceFirstLn);
         WriteInt(High(ceTotalTime)-Low(ceTotalTime)+1);
         for j := Low(ceTotalTime) to High(ceTotalTime) do
-          WriteInt64(ceTotalTime[j]);
+          WriteUInt64(ceTotalTime[j]);
         WriteInt(High(ceTotalCnt)-Low(ceTotalCnt)+1);
         for j := Low(ceTotalCnt) to High(ceTotalCnt) do
           WriteInt(ceTotalCnt[j]);
@@ -1133,22 +1135,22 @@ begin
         WriteInt(peFirstLn);
         WriteInt(High(peProcTime)-Low(peProcTime)+1);
         for j := Low(peProcTime) to High(peProcTime) do
-          WriteInt64(peProcTime[j]);
+          WriteUInt64(peProcTime[j]);
         WriteInt(High(peProcTimeMin)-Low(peProcTimeMin)+1);
         for j := Low(peProcTimeMin) to High(peProcTimeMin) do
-          WriteInt64(peProcTimeMin[j]);
+          WriteUInt64(peProcTimeMin[j]);
         WriteInt(High(peProcTimeMax)-Low(peProcTimeMax)+1);
         for j := Low(peProcTimeMax) to High(peProcTimeMax) do
-          WriteInt64(peProcTimeMax[j]);
+          WriteUInt64(peProcTimeMax[j]);
         WriteInt(High(peProcChildTime)-Low(peProcChildTime)+1);
         for j := Low(peProcChildTime) to High(peProcChildTime) do
-          WriteInt64(peProcChildTime[j]);
+          WriteUInt64(peProcChildTime[j]);
         WriteInt(High(peProcCnt)-Low(peProcCnt)+1);
         for j := Low(peProcCnt) to High(peProcCnt) do
           WriteInt(peProcCnt[j]);
         WriteInt(High(peProcTimeAvg)-Low(peProcTimeAvg)+1);
         for j := Low(peProcTimeAvg) to High(peProcTimeAvg) do
-          WriteInt64(peProcTimeAvg[j]);
+          WriteUInt64(peProcTimeAvg[j]);
         WriteInt(High(peProcMem)-Low(peProcMem)+1);
         for j := Low(peProcMem) to High(peProcMem) do
           WriteInt64(peProcMem[j]);
@@ -1165,17 +1167,17 @@ begin
           WriteInt(k);
           WriteInt(LInfo.ProcTime.Count); // number of threads
           for j := 0 to LInfo.ProcTime.Count-1 do
-            WriteInt64(LInfo.ProcTime[j]);
+            WriteUInt64(LInfo.ProcTime[j]);
           for j := 0 to LInfo.ProcTimeMin.Count-1 do
-            WriteInt64(LInfo.ProcTimeMin[j]);
+            WriteUInt64(LInfo.ProcTimeMin[j]);
           for j := 0 to LInfo.ProcTimeMax.Count-1 do
-            WriteInt64(LInfo.ProcTimeMax[j]);
+            WriteUInt64(LInfo.ProcTimeMax[j]);
           for j := 0 to LInfo.ProcChildTime.Count-1 do
-            WriteInt64(LInfo.ProcChildTime[j]);
+            WriteUInt64(LInfo.ProcChildTime[j]);
           for j := 0 to LInfo.ProcCnt.Count-1 do
             WriteInt(LInfo.ProcCnt[j]);
           for j := 0 to LInfo.ProcTimeAvg.Count-1 do
-            WriteInt64(LInfo.ProcTimeAvg[j]);
+            WriteUInt64(LInfo.ProcTimeAvg[j]);
         end;
       end;
     end;
@@ -1239,7 +1241,7 @@ begin
             UpdateStatus;
             ReadInt(teThread);
             ReadString(teName);
-            ReadInt64(teTotalTime);
+            ReadUInt64(teTotalTime);
             ReadInt(teTotalCnt);
             ReadInt64(teTotalMem);
           end;
@@ -1254,7 +1256,7 @@ begin
             ReadString(ueQual);
             ReadInt(num);
             SetLength(ueTotalTime,num);
-            for j := Low(ueTotalTime) to High(ueTotalTime) do ReadInt64(ueTotalTime[j]);
+            for j := Low(ueTotalTime) to High(ueTotalTime) do ReadUInt64(ueTotalTime[j]);
             ReadInt(num);
             SetLength(ueTotalCnt,num);
             for j := Low(ueTotalCnt) to High(ueTotalCnt) do ReadInt(ueTotalCnt[j]);
@@ -1274,7 +1276,7 @@ begin
             ReadInt(ceFirstLn);
             ReadInt(num);
             SetLength(ceTotalTime,num);
-            for j := Low(ceTotalTime) to High(ceTotalTime) do ReadInt64(ceTotalTime[j]);
+            for j := Low(ceTotalTime) to High(ceTotalTime) do ReadUInt64(ceTotalTime[j]);
             ReadInt(num);
             SetLength(ceTotalCnt,num);
             for j := Low(ceTotalCnt) to High(ceTotalCnt) do ReadInt(ceTotalCnt[j]);

--- a/source/model/profilingResultParser/gppresults.pas
+++ b/source/model/profilingResultParser/gppresults.pas
@@ -26,7 +26,7 @@ type
     teTotalTime  : int64;
     teTotalCnt   : integer;
     teActiveProcs: TActiveProcList;
-    teTotalMem  : Cardinal;
+    teTotalMem   : int64;
 
     property Name : String read GetName;
   end;
@@ -40,7 +40,7 @@ type
     ueQual     : AnsiString;
     ueTotalTime: array {thread} of int64;   // 0 = sum
     ueTotalCnt : array {thread} of integer; // 0 = sum
-    ueTotalMem: array {thread} of Cardinal;   // 0 = sum
+    ueTotalMem: array {thread} of int64;   // 0 = sum
 
     property FilePath : String read GetPath;
     property Name : String read GetName;
@@ -55,7 +55,7 @@ type
     ceFirstLn  : integer;
     ceTotalTime: array {thread} of int64;   // 0 = sum
     ceTotalCnt : array {thread} of integer; // 0 = sum
-    ceTotalMem: array {thread} of Cardinal;   // 0 = sum
+    ceTotalMem: array {thread} of int64;   // 0 = sum
 
     property Name : String read GetName;
   end;
@@ -117,9 +117,9 @@ type
     procedure   ReadThread(var thread: integer);
     procedure   ReadTicks(var ticks: int64);
     procedure   ReadID(var id: integer);
+    procedure   ReadMem(var value: int64);
     procedure   WriteTag(tag: byte);
     procedure   WriteInt(int: integer);
-    procedure   WriteCardinal  (uint: Cardinal);
     procedure   WriteInt64(i64: int64);
     procedure   WriteString(str: ansistring);
     procedure   CheckTag(tag: byte);
@@ -233,6 +233,15 @@ end; { TResults.Destroy }
 procedure TResults.ReadInt  (var int: integer);  begin resFile.BlockReadUnsafe(int,SizeOf(integer)); end;
 procedure TResults.ReadCardinal(var value: Cardinal);  begin resFile.BlockReadUnsafe(value,SizeOf(Cardinal)); end;
 procedure TResults.ReadInt64(var i64: int64);    begin resFile.BlockReadUnsafe(i64,SizeOf(int64)); end;
+
+procedure TResults.ReadMem(var value: int64);
+var
+  tmp: Cardinal;
+begin
+  resFile.BlockReadUnsafe(tmp,SizeOf(Cardinal));
+  value := tmp;
+end;
+
 procedure TResults.ReadUInt64(var ui64: uint64);    begin resFile.BlockReadUnsafe(ui64,SizeOf(uint64)); end;
 procedure TResults.ReadTag  (var tag: byte);     begin resFile.BlockReadUnsafe(tag,SizeOf(byte)); end;
 procedure TResults.ReadID   (var id: integer);   begin id := 0; resFile.BlockReadUnsafe(id,resProcSize); end;
@@ -297,7 +306,6 @@ end; { TResults.ReadString }
 
 procedure TResults.WriteTag  (tag: byte);    begin resFile.BlockWriteUnsafe(tag,SizeOf(byte)); end;
 procedure TResults.WriteInt  (int: integer); begin resFile.BlockWriteUnsafe(int,SizeOf(integer)); end;
-procedure TResults.WriteCardinal  (uint: Cardinal); begin resFile.BlockWriteUnsafe(uint,SizeOf(Cardinal)); end;
 procedure TResults.WriteInt64(i64: int64);   begin resFile.BlockWriteUnsafe(i64,SizeOf(int64)); end;
 
 procedure TResults.WriteString(str: ansistring);
@@ -655,7 +663,7 @@ begin
       rpMeasurePointID := utf8ToString(lAnsiMeasurePointId);
       ReadTicks(rpMeasure1);
       if IsMemProfilingEnabled then
-        ReadCardinal(pktMem.rpMemWorkingSize);
+        ReadMem(pktMem.rpMemWorkingSize);
       ReadTicks(rpMeasure2);
       Result := true;
     end
@@ -666,7 +674,7 @@ begin
       ReadTicks(rpMeasure1);
       if IsMemProfilingEnabled then
         if (rpTag = PR_ENTERPROC) or (rpTag = PR_EXITPROC) then
-          ReadCardinal(pktMem.rpMemWorkingSize);
+          ReadMem(pktMem.rpMemWorkingSize);
       ReadTicks(rpMeasure2);
       Result := true;
     end;
@@ -1075,7 +1083,7 @@ begin
         WriteString(teName);
         WriteInt64(teTotalTime);
         WriteInt(teTotalCnt);
-        WriteCardinal(teTotalMem);
+        WriteInt64(teTotalMem);
       end;
     WriteTag(PR_DIGUNITS);
     WriteInt(lNumberOfUnits);
@@ -1092,7 +1100,7 @@ begin
           WriteInt(ueTotalCnt[j]);
         WriteInt(High(ueTotalMem)-Low(ueTotalMem)+1);
         for j := Low(ueTotalMem) to High(ueTotalMem) do
-          WriteCardinal(ueTotalMem[j]);
+          WriteInt64(ueTotalMem[j]);
       end;
     WriteTag(PR_DIGCLASSES);
 
@@ -1111,7 +1119,7 @@ begin
           WriteInt(ceTotalCnt[j]);
         WriteInt(High(ceTotalMem)-Low(ceTotalMem)+1);
         for j := Low(ceTotalMem) to High(ceTotalMem) do
-          WriteCardinal(ceTotalMem[j]);
+          WriteInt64(ceTotalMem[j]);
       end;
     WriteTag(PR_DIGPROCS);
     WriteInt(lNumberOfProcedures);
@@ -1143,7 +1151,7 @@ begin
           WriteInt64(peProcTimeAvg[j]);
         WriteInt(High(peProcMem)-Low(peProcMem)+1);
         for j := Low(peProcMem) to High(peProcMem) do
-          WriteCardinal(peProcMem[j]);
+          WriteInt64(peProcMem[j]);
       end;
     WriteTag(PR_DIGCALLG);
     for i := 0 to fCallGraphInfoMaxElementCount do
@@ -1233,7 +1241,7 @@ begin
             ReadString(teName);
             ReadInt64(teTotalTime);
             ReadInt(teTotalCnt);
-            ReadCardinal(teTotalMem);
+            ReadInt64(teTotalMem);
           end;
       end; // PR_DIGTHREADS;
       PR_DIGUNITS: begin
@@ -1252,7 +1260,7 @@ begin
             for j := Low(ueTotalCnt) to High(ueTotalCnt) do ReadInt(ueTotalCnt[j]);
             ReadInt(num);
             SetLength(ueTotalMem,num);
-            for j := Low(ueTotalMem) to High(ueTotalMem) do ReadCardinal(ueTotalMem[j]);
+            for j := Low(ueTotalMem) to High(ueTotalMem) do ReadInt64(ueTotalMem[j]);
           end;
       end; // PR_DIGUNITS
       PR_DIGCLASSES: begin
@@ -1272,7 +1280,7 @@ begin
             for j := Low(ceTotalCnt) to High(ceTotalCnt) do ReadInt(ceTotalCnt[j]);
             ReadInt(num);
             SetLength(ceTotalMem,num);
-            for j := Low(ceTotalMem) to High(ceTotalMem) do ReadCardinal(ceTotalMem[j]);
+            for j := Low(ceTotalMem) to High(ceTotalMem) do ReadInt64(ceTotalMem[j]);
           end;
       end; // PR_DIGCLASSES
       PR_DIGPROCS: begin
@@ -1308,7 +1316,7 @@ begin
             for j := Low(peProcTimeAvg) to High(peProcTimeAvg) do ReadUInt64(peProcTimeAvg[j]);
             ReadInt(num);
             SetLength(peProcMem,num);
-            for j := Low(peProcMem) to High(peProcMem) do ReadCardinal(peProcMem[j]);
+            for j := Low(peProcMem) to High(peProcMem) do ReadInt64(peProcMem[j]);
           end;
       end; // PR_DIGPROCS
       PR_DIGCALLG: begin

--- a/source/ui/VirtualTree.Tools/virtualTree.tools.base.pas
+++ b/source/ui/VirtualTree.Tools/virtualTree.tools.base.pas
@@ -242,7 +242,8 @@ end;
 
 class function TVirtualTreeBaseTools.FormatMem(const value: double): string;
 begin
-  Result := Format('%.6n',[value]);
+  Result := Format('%.0n', [value]);
+  if value > 0 then Result := '+' + Result;
 end;
 
 

--- a/source/ui/VirtualTree.Tools/virtualTree.tools.memorystatistics.pas
+++ b/source/ui/VirtualTree.Tools/virtualTree.tools.memorystatistics.pas
@@ -454,7 +454,13 @@ begin
     TotalMem := fProfileResults.resUnits[0].ueTotalMem[fThreadIndex];
     case Column of
       COL_UNIT_NAME: CellText := fProfileResults.resUnits[LData.UnitId].Name;
-      COL_UNIT_TOTAL_PERC: CellText := FormatPerc(fProfileResults.resUnits[LData.UnitId].ueTotalMem[fThreadIndex]/TotalMem);
+      COL_UNIT_TOTAL_PERC:
+      begin
+        if TotalMem = 0  then
+          CellText := FormatPerc(0)
+        else
+          CellText := FormatPerc(fProfileResults.resUnits[LData.UnitId].ueTotalMem[fThreadIndex]/TotalMem);
+      end;
       COL_UNIT_TOTAL_MEM: CellText := FormatMem(fProfileResults.resUnits[LData.UnitId].ueTotalMem[fThreadIndex]);
       COL_UNIT_TOTAL_CALLS: CellText := FormatCnt(fProfileResults.resUnits[LData.UnitId].ueTotalCnt[fThreadIndex]);
     end;

--- a/source/ui/VirtualTree.Tools/virtualTree.tools.memorystatistics.pas
+++ b/source/ui/VirtualTree.Tools/virtualTree.tools.memorystatistics.pas
@@ -103,7 +103,7 @@ const
   COL_THREAD_ID = 0;
   COL_THREAD_NAME = 1;
   COL_THREAD_TOTAL_PERC = 2;
-  COL_THREAD_TOTAL_TIME = 3;
+  COL_THREAD_TOTAL_MEM = 3;
   COL_THREAD_TOTAL_CALLS = 4;
 
 
@@ -283,13 +283,13 @@ begin
     case aColumnIndex of
       COL_THREAD_TOTAL_PERC:
         result := TColumnInfoType.Percent;
-      COL_THREAD_TOTAL_TIME:
+      COL_THREAD_TOTAL_MEM:
         result := TColumnInfoType.Mem;
       COL_THREAD_TOTAL_CALLS:
         result := TColumnInfoType.Count;
     end;
   end;
-  
+
 end;
 
 function TSimpleMemStatsListTools.GetValue(const aData : PMemoryInfoRec;const aColumnIndex: integer;out aValue, aMax : double; out aColRenderType:TColumnInfoType): boolean;
@@ -421,7 +421,7 @@ begin
         aValue := fProfileResults.resThreads[aData.ThreadId].teTotalMem;
         aMax := LTotalMem;
       end;
-      COL_THREAD_TOTAL_TIME:
+      COL_THREAD_TOTAL_MEM:
       begin
         aValue := fProfileResults.resThreads[aData.ThreadId].teTotalMem;
         aMax := LTotalMem;
@@ -560,7 +560,7 @@ begin
         else
           CellText := FormatPerc(fProfileResults.resThreads[LData.ThreadId].teTotalMem/TotalMem);
       end;
-      COL_THREAD_TOTAL_TIME: CellText := FormatMem(fProfileResults.resThreads[LData.ThreadId].teTotalMem);
+      COL_THREAD_TOTAL_MEM: CellText := FormatMem(fProfileResults.resThreads[LData.ThreadId].teTotalMem);
       COL_THREAD_TOTAL_CALLS: CellText := FormatCnt(fProfileResults.resThreads[LData.ThreadId].teTotalCnt);
     end;
   end;

--- a/source/ui/gppmain.FrameMemoryAnalysis.dfm
+++ b/source/ui/gppmain.FrameMemoryAnalysis.dfm
@@ -508,13 +508,13 @@ object frmMemProfiling: TfrmMemProfiling
           item
             MinWidth = 75
             Position = 2
-            Text = '% Time'
+            Text = '% Memory'
             Width = 75
           end
           item
             MinWidth = 75
             Position = 3
-            Text = 'Time'
+            Text = 'Memory'
             Width = 75
           end
           item


### PR DESCRIPTION
Performance (affects Classes, Units, and Threads tabs):

<img width="556" height="343" alt="LLq30MkvfF" src="https://github.com/user-attachments/assets/461e15ea-d84a-4375-ad20-a54ede3ece62" />

----

Memory (all tabs):
<img width="854" height="188" alt="TCbaLVEqsl" src="https://github.com/user-attachments/assets/c9aedfba-7f58-43dd-9d1d-ac8dd56cc5f0" />

----

Test code:
```pascal
program Project1;

{$APPTYPE CONSOLE}

uses
  SysUtils,
  Unit1 in 'Unit1.pas';

procedure DoTest;
var
  p: Pointer;
begin
  p := DoAlloc;
  DoFree(p);

  DoAlloc; // test mem leak
end;

begin
  try
    DoTest;
  except
    on E: Exception do
      Writeln(E.ClassName + ': ' + E.Message);
  end;

  Writeln('Press ENTER to Exit...');
  Readln;
end.
```
Unit1.pas:
```pascal
unit Unit1;

interface

function DoAlloc: Pointer;
procedure DoFree(var p: Pointer);

implementation

function DoAlloc: Pointer;
begin
  GetMem(Result, 1024);
end;

procedure DoFree(var p: Pointer);
begin
  FreeMem(p);
  P := nil;
end;

end.
```