### PR TITLE
Fix build and compress scripts

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,9 +1,7 @@
-# Build gpprof for Win32 and Win64 and deploy to BIN/ and bin64/
+# Build gpprof for Win32 and Win64
 #
 # Requirements:
-#   - Delphi RAD Studio (paid/professional edition) installed at
-#     %ProgramFiles(x86)%\Embarcadero\Studio\<version>
-#     (auto-detects the latest installed version from 99.0 down to 21.0)
+#   - Delphi RAD Studio (paid/professional edition) installed
 #     NOTE: The Community Edition does NOT support command-line compilation.
 #           You need a Professional, Enterprise, or Architect edition.
 #   - Windows PowerShell 5.1 or later
@@ -12,54 +10,93 @@
 #   .\scripts\build.ps1
 #   .\scripts\build.ps1 -Config Release
 #   .\scripts\build.ps1 -Config Debug
+#   .\scripts\build.ps1 -BDS 23
 
 param(
-    [string]$Config = "Release"
+    [string]$Config  = "Release",
+    
+    # Specific RAD Studio version (e.g., "21" or "21.0")
+    [string]$BDS     = ""
 )
 
 $ErrorActionPreference = "Stop"
 
-$repoRoot   = Resolve-Path "$PSScriptRoot\.."
+$scriptDir   = if ($PSScriptRoot) { $PSScriptRoot } else { $PWD.Path }
+$repoRoot    = (Resolve-Path (Join-Path $scriptDir "..")).Path
 $projectFile = Join-Path $repoRoot "source\gpprof.dproj"
-$binDir     = Join-Path $repoRoot "BIN"
-$bin64Dir   = Join-Path $repoRoot "bin64"
+$binDir      = Join-Path $repoRoot "bin"
+$bin64Dir    = Join-Path $repoRoot "bin64"
 
 if (-not (Test-Path $projectFile)) {
     Write-Error "Project file not found: $projectFile"
     exit 1
 }
 
+# Normalize version string (e.g., "21" -> "21.0")
+if ($BDS -and ($BDS -notmatch '\.')) {
+    $BDS = "$BDS.0"
+}
+
 ###########################################################################
-# SET BDS AND LOAD FULL DELPHI BUILD ENVIRONMENT VIA rsvars.bat
+# LOCATE RAD STUDIO AND LOAD ITS BUILD ENVIRONMENT VIA rsvars.bat
 ###########################################################################
 
-# Auto-detect the latest installed RAD Studio version (99.0 down to 21.0)
+# Detect RAD Studio version
 $DelphiInstallLocation = $null
-$studioBase = "${Env:ProgramFiles(x86)}\Embarcadero\Studio"
-for ($v = 99; $v -ge 21; $v--) {
-    $candidate = "$studioBase\$v.0"
-    if (Test-Path $candidate) {
-        $DelphiInstallLocation = $candidate
-        break
+
+$registryRoots = @(
+    'HKLM:\SOFTWARE\WOW6432Node\Embarcadero\BDS',
+    'HKLM:\SOFTWARE\Embarcadero\BDS',
+    'HKCU:\Software\Embarcadero\BDS'
+)
+
+foreach ($regRoot in $registryRoots) {
+    if (Test-Path $regRoot) {
+        if ($BDS) {
+            # Search for specific version
+            $verPath = Join-Path $regRoot $BDS
+            if (Test-Path $verPath) {
+                $rootDir = (Get-ItemProperty -Path $verPath -Name 'RootDir' -ErrorAction SilentlyContinue).RootDir
+                if ($rootDir -and (Test-Path $rootDir)) {
+                    $DelphiInstallLocation = $rootDir.TrimEnd('\')
+                    break
+                }
+            }
+        } else {
+            # Auto-detect the latest version
+            $versions = Get-ChildItem $regRoot -ErrorAction SilentlyContinue |
+                Where-Object { $_.PSChildName -match '^\d+\.\d+$' } |
+                Sort-Object { [double]$_.PSChildName } -Descending
+
+            foreach ($ver in $versions) {
+                $rootDir = (Get-ItemProperty -Path $ver.PSPath -Name 'RootDir' -ErrorAction SilentlyContinue).RootDir
+                if ($rootDir -and (Test-Path $rootDir)) {
+                    $DelphiInstallLocation = $rootDir.TrimEnd('\')
+                    break
+                }
+            }
+        }
     }
+    if ($DelphiInstallLocation) { break }
 }
 
 if (-not $DelphiInstallLocation) {
-    Write-Error "Couldn't find Delphi Install in $studioBase (searched 99.0 down to 21.0)"
+    $errorMsg = if ($BDS) { "Couldn't find RAD Studio version $BDS" } else { "Couldn't find any RAD Studio installation" }
+    Write-Error $errorMsg
     exit 1
 } else {
-    Write-Host "Found Delphi Install at $DelphiInstallLocation"
+    Write-Host "Found RAD Studio at: $DelphiInstallLocation"
     $env:BDS = $DelphiInstallLocation
 }
 
-# rsvars.bat sets BDS, BDSPLATFORMSDKSDIR, FrameworkDir, FrameworkVersion,
-# MSBUILD_VERSION and adds the correct MSBuild.exe to PATH.
+# Load environment variables via rsvars.bat
 $rsVars = Join-Path $DelphiInstallLocation "bin\rsvars.bat"
 if (-not (Test-Path $rsVars)) {
     Write-Error "rsvars.bat not found at: $rsVars"
     exit 1
 }
-Write-Host "Loading Delphi environment from $rsVars"
+
+Write-Host "Loading RAD Studio environment from: $rsVars"
 cmd /c "`"$rsVars`" && set" | ForEach-Object {
     if ($_ -match '^([^=]+)=(.*)$') {
         [Environment]::SetEnvironmentVariable($Matches[1], $Matches[2], 'Process')
@@ -73,35 +110,38 @@ if (-not $msbuild) {
     exit 1
 }
 
-Write-Host "Using MSBuild: $msbuild" -ForegroundColor Cyan
-Write-Host "Project: $projectFile" -ForegroundColor Cyan
-Write-Host "Config:  $Config" -ForegroundColor Cyan
+Write-Host "Using MSBuild : $msbuild" -ForegroundColor Cyan
+Write-Host "Project       : $projectFile" -ForegroundColor Cyan
+Write-Host "Config        : $Config" -ForegroundColor Cyan
 Write-Host ""
 Write-Warning "NOTE: Command-line compilation requires a paid RAD Studio edition (Professional/Enterprise/Architect). The Community Edition is NOT supported and will fail with 'This version does not support command line compiling'."
 
-# Ensure output directories exist
+# Ensure output directories exist before MSBuild runs
 New-Item -Path $binDir   -ItemType Directory -Force | Out-Null
 New-Item -Path $bin64Dir -ItemType Directory -Force | Out-Null
 
-# Build Win32
-Write-Host ""
-Write-Host "Building Win32 ($Config)..." -ForegroundColor Green
-& $msbuild $projectFile /t:Build /p:Config=$Config /p:Platform=Win32 /nologo /v:minimal
-if ($LASTEXITCODE -ne 0) {
-    Write-Error "Win32 build failed with exit code $LASTEXITCODE"
-    exit $LASTEXITCODE
-}
-Write-Host "Win32 build succeeded. Output: $binDir" -ForegroundColor Green
+###########################################################################
+# BUILD
+###########################################################################
 
-# Build Win64
-Write-Host ""
-Write-Host "Building Win64 ($Config)..." -ForegroundColor Green
-& $msbuild $projectFile /t:Build /p:Config=$Config /p:Platform=Win64 /nologo /v:minimal
-if ($LASTEXITCODE -ne 0) {
-    Write-Error "Win64 build failed with exit code $LASTEXITCODE"
-    exit $LASTEXITCODE
+$platforms = @(
+    @{ Name = "Win32"; OutDir = $binDir }
+    @{ Name = "Win64"; OutDir = $bin64Dir }
+)
+
+foreach ($p in $platforms) {
+    Write-Host ""
+    Write-Host "Building $($p.Name) ($Config)..." -ForegroundColor Green
+    
+    & $msbuild $projectFile /t:Build /p:Config=$Config /p:Platform=$($p.Name) /nologo /v:minimal
+    
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "$($p.Name) build failed with exit code $LASTEXITCODE"
+        exit $LASTEXITCODE
+    }
+    
+    Write-Host "$($p.Name) build succeeded. Output: $($p.OutDir)" -ForegroundColor Green
 }
-Write-Host "Win64 build succeeded. Output: $bin64Dir" -ForegroundColor Green
 
 Write-Host ""
 Write-Host "Build complete." -ForegroundColor Cyan

--- a/scripts/buildReleaseZips.cmd
+++ b/scripts/buildReleaseZips.cmd
@@ -1,0 +1,9 @@
+@echo off
+
+powershell -ExecutionPolicy Bypass -File .\build.ps1 -Config Release
+
+echo.
+
+powershell -ExecutionPolicy Bypass -File .\compressReleaseZips.ps1
+
+pause

--- a/scripts/compressReleaseZips.ps1
+++ b/scripts/compressReleaseZips.ps1
@@ -1,42 +1,58 @@
 $version = "1.6.0.10"
-$repoRoot = Resolve-Path "$PSScriptRoot\.."
-$srcBin32 = Join-Path $repoRoot "bin"
-$srcBin64 = Join-Path $repoRoot "bin64"
-$targetFolder32 = Join-Path $repoRoot ("gpprof_2017_v" + $version)
-$targetFolder32Include = Join-Path $targetFolder32 "include"
-$targetFolder64 = Join-Path $repoRoot ("gpprof_2017x64_v" + $version)
-$targetFolder64Include = Join-Path $targetFolder64 "include"
-$targetZip32 = Join-Path $repoRoot ("gpprof_2017_v" + $version + ".zip")
-$targetZip64 = Join-Path $repoRoot ("gpprof_2017x64_v" + $version + ".zip")
+
+$scriptDir   = if ($PSScriptRoot) { $PSScriptRoot } else { $PWD.Path }
+$repoRoot    = (Resolve-Path (Join-Path $scriptDir "..")).Path
+$includeDir  = Join-Path $repoRoot "include"
+
+$buildConfigs = @(
+    @{
+        Name      = "32-bit"
+        SrcBin    = Join-Path $repoRoot "bin"
+        TargetDir = Join-Path $repoRoot "gpprof_2017_v$version"
+    },
+    @{
+        Name      = "64-bit"
+        SrcBin    = Join-Path $repoRoot "bin64"
+        TargetDir = Join-Path $repoRoot "gpprof_2017x64_v$version"
+    }
+)
+
+foreach ($config in $buildConfigs) {
+    Write-Host "Creating $($config.Name) release zip" -ForegroundColor Cyan
     
-if (Test-Path -Path $targetFolder32) {
-    Write-Host "$targetFolder32 already exists, recreating it"
-    Remove-Item $targetFolder32 -Recurse
+    $zipFile = $config.TargetDir + ".zip"
+    
+    # Clean up existing temporary folders and old archives
+    if (Test-Path $config.TargetDir) {
+        Write-Host "Removing existing temporary folder: $($config.TargetDir)" -ForegroundColor DarkGray
+        Remove-Item $config.TargetDir -Recurse -Force
+    }
+    if (Test-Path $zipFile) {
+        Write-Host "Removing old archive: $zipFile" -ForegroundColor DarkGray
+        Remove-Item $zipFile -Force
+    }
+
+    # Create directory structure
+    Write-Host "Creating folder structure..." -ForegroundColor Green
+    $targetInclude = Join-Path $config.TargetDir "include"
+    New-Item -Path $targetInclude -ItemType Directory -Force | Out-Null
+
+    # Copy binary artifacts (.exe, .chm, .eul)
+    Write-Host "Copying binaries from $($config.SrcBin)..." -ForegroundColor Gray
+    Copy-Item -Path "$($config.SrcBin)\*" -Include "*.exe", "*.chm", "*.eul" -Destination $config.TargetDir
+
+    # Copy include files (.pas, .inc)
+    Write-Host "Copying include files..." -ForegroundColor Gray
+    Copy-Item -Path "$includeDir\*" -Include "*.pas", "*.inc" -Destination $targetInclude
+
+    # Create new archive
+    Write-Host "Creating archive: $zipFile" -ForegroundColor Yellow
+    Compress-Archive -LiteralPath $config.TargetDir -DestinationPath $zipFile
+
+    # Final cleanup of the temporary folder
+    Write-Host "Cleaning up temporary folder..." -ForegroundColor DarkGray
+    Remove-Item $config.TargetDir -Recurse -Force
 }
-if (Test-Path -Path $targetFolder64) {
-    Write-Host "$targetFolder64 already exists, recreating it"
-    Remove-Item $targetFolder64 -Recurse
-}
 
-Write-Host "Creating 32 bit folder structure" -f Green
-New-item -Path $targetFolder32 -ItemType Directory -Force	 | Out-Null
-New-item -Path $targetFolder32Include -ItemType Directory	-Force | Out-Null
-
-Write-Host "Copying bin32 artefacts from $srcBin32\* to $targetFolder32" -f Green
-Copy-Item -Path $srcBin32\* -Include *.exe, *.chm, *.eul -Destination $targetFolder32
-$includeDir = Join-Path $repoRoot "include"
-Copy-Item -Path (Join-Path $includeDir "*") -Include *.pas -Destination $targetFolder32Include
-Compress-Archive -LiteralPath $targetFolder32 -DestinationPath $targetZip32
-
-
-Write-Host "Creating 64 bit folder structure" -f Green
-New-item -Path $targetFolder64 -ItemType Directory -Force	 | Out-Null
-New-item -Path $targetFolder64Include -ItemType Directory	-Force | Out-Null
-
-
-Write-Host "Copying bin64 artefacts from $srcBin64\* to $targetFolder64" -f Green
-Copy-Item -Path $srcBin64\* -Include *.exe, *.chm, *.eul -Destination $targetFolder64
-Copy-Item -Path (Join-Path $includeDir "*") -Include *.pas -Destination $targetFolder64Include
-
-Compress-Archive -LiteralPath $targetFolder64 -DestinationPath $targetZip64
+Write-Host "Done" -ForegroundColor Green
 


### PR DESCRIPTION
- build: added option to specify custom Delphi version
- build: search for the latest Delphi version via registry
- build: refactor Win32 and Win64 builds into a loop
- compress: added missing `*.inc` file extension
- compress: refactor to use loop for 32 and 64 bit zips
- all: added a CMD script to build and compress release zips in a single step

I have installed both D13.1 and D12 and with previous script it was impossible to build, since GpProf doesn't support D13 yet:
```
model\gppIDT.pas(213): error E2010: Incompatible types: '{System.Generics.Collections}TList<gppTree.INode<gppTree.TRootNode<T>.T>>.TEnumerator' and 'TList<INode<TIDTableUnitEntry>>.TEnumerator' 
```
Now, I can specify `-BDS 23` switch to use D12 for build.